### PR TITLE
Add menu and essential shortcuts

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -1,0 +1,5 @@
+const HOMEPAGE_URL = 'https://github.com/chriskol/Desktop-for-Google-Keep-Electron';
+
+module.exports = {
+  HOMEPAGE_URL
+};

--- a/main.js
+++ b/main.js
@@ -1,4 +1,5 @@
 const electron = require('electron')
+const menu = require('./menu');
 // Module to control application life.
 const app = electron.app
 // Module to create native browser window.
@@ -8,9 +9,10 @@ const BrowserWindow = electron.BrowserWindow
 // be closed automatically when the JavaScript object is garbage collected.
 let mainWindow
 
-function createWindow () {
+function createWindow() {
   // Create the browser window.
-  mainWindow = new BrowserWindow({width: 1050, height: 800})
+  mainWindow = new BrowserWindow({width: 1050, height: 800});
+  electron.Menu.setApplicationMenu(menu);
 
   // and load the index.html of the app.
   //mainWindow.loadURL(`file://${__dirname}/index.html`)

--- a/menu.js
+++ b/menu.js
@@ -1,0 +1,89 @@
+const {app, Menu, shell} = require('electron');
+const {HOMEPAGE_URL} = require('./constants');
+
+const template = [{
+  label: 'Edit',
+  submenu: [{
+    role: 'undo'
+  }, {
+    role: 'redo'
+  }, {
+    type: 'separator'
+  }, {
+    role: 'cut'
+  }, {
+    role: 'copy'
+  }, {
+    role: 'paste'
+  }, {
+    type: 'separator'
+  }, {
+    role: 'delete'
+  }, {
+    role: 'selectall'
+  }]
+}, {
+  label: 'View',
+  submenu: [{
+    role: 'reload'
+  }, {
+    role: 'toggledevtools'
+  }, {
+    type: 'separator'
+  }, {
+    role: 'resetzoom'
+  }, {
+    role: 'zoomin'
+  }, {
+    role: 'zoomout'
+  },{
+    type: 'separator'
+  }, {
+    role: 'togglefullscreen'
+  }]
+},
+{
+  role: 'window',
+  submenu: [{
+    role: 'minimize'
+  }, {
+    role: 'close'
+  }]
+},
+{
+  role: 'help',
+  submenu: [{
+    label: 'Learn More',
+    click () {
+      shell.openExternal(HOMEPAGE_URL);
+    }
+  }]
+}
+];
+
+if (process.platform === 'darwin') {
+  template.unshift({
+    label: app.getName(),
+    submenu: [{
+      role: 'about'
+    }, {
+      type: 'separator'
+    }, {
+      type: 'separator'
+    }, {
+      role: 'hide'
+    }, {
+      role: 'hideothers'
+    }, {
+      role: 'unhide'
+    }, {
+      type: 'separator'
+    }, {
+      role: 'quit'
+    }]
+  });
+};
+
+const menu = Menu.buildFromTemplate(template);
+
+module.exports = menu;


### PR DESCRIPTION
Shortcuts aren't working. I've added the menu which brings essential shortcuts such as:

- Application menu (OS X only):
  - About
  - Hide Google Keep Desktop
  - Hide others
  - Show all
  - Quit Google Keep Desktop
- Edit
  - Undo
  - Redo
  - Cut
  - Copy
  - Paste
  - Delete
  - Select all
- View
  - Toggle devtools
  - Actual size
  - Zoom in
  - Zoom out
  - Toggle fullscreen
- Window
  - Minimize
  - Close window
- Help
  - Learn more (link to github repo)